### PR TITLE
[DNM]: Test secondary CI with 8.0 and 8.1

### DIFF
--- a/.github/workflows/secondaryCI.yml
+++ b/.github/workflows/secondaryCI.yml
@@ -1,7 +1,5 @@
 name: Wikibase Secondary CI
-on:
-  push:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   secondary-ci:
@@ -12,46 +10,22 @@ jobs:
         include:
         - env:
             MW_BRANCH: master
-            DBTYPE: sqlite
-            LANG: ru
-            WB: both
-          php-versions: '7.3.27'
-        - env:
-            MW_BRANCH: master
-            DBTYPE: sqlite
-            LANG: en
-            WB: client
-          php-versions: '7.2.34'
-        - env:
-            MW_BRANCH: master
-            DBTYPE: mysql
-            LANG: en
-            WB: repo
-          php-versions: '7.2.34'
-        - env:
-            MW_BRANCH: master
-            DBTYPE: sqlite
-            LANG: ar
-            WB: both
-          php-versions: '7.3.27'
-        - env:
-            MW_BRANCH: master
-            DBTYPE: mysql
-            LANG: en
-            WB: both
-          php-versions: '7.2.34'
-        - env:
-            MW_BRANCH: master
-            DBTYPE: mysql
-            LANG: en
-            WB: both
-          php-versions: '7.3.27'
-        - env:
-            MW_BRANCH: master
             DBTYPE: mysql
             LANG: en
             WB: both
           php-versions: '7.4.15'
+        - env:
+            MW_BRANCH: master
+            DBTYPE: mysql
+            LANG: en
+            WB: both
+          php-versions: '8.0.24'
+        - env:
+            MW_BRANCH: master
+            DBTYPE: mysql
+            LANG: en
+            WB: both
+          php-versions: '8.1.11'
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -87,26 +61,3 @@ jobs:
       env: ${{ matrix.env }}
       run: |
         bash ./build/ci-scripts/script.sh
-    - name: Send mail
-      if: ${{ failure() }}
-      uses: dawidd6/action-send-mail@v3.7.0
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.MAIL_USERNAME}}
-        password: ${{secrets.MAIL_PASSWORD}}
-        subject: Github Action job failed for Wikibase
-        html_body: |
-          Job secondary-ci failed!
-          The failed job can be found in <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">here</a>
-          <h3>Specifications of the failed job:</h3>
-          <ul>
-          <li>php version: ${{ matrix.php-versions }}</li>
-          <li>Database type: ${{ matrix.env.DBTYPE }}</li>
-          <li>MediaWiki language: ${{ matrix.env.LANG }}</li>
-          <li>Wikibase type: ${{ matrix.env.WB }}</li>
-          <li>MediaWiki core branch: ${{ matrix.env.MW_BRANCH }}</li>
-          </ul>
-          CI specifications can be found in <a href="https://github.com/${{ github.repository }}/actions/workflows/secondaryCI.yml">here</a>
-        to: wikidata-ci-status@wikimedia.de
-        from: Wikibase Github Action CI


### PR DESCRIPTION
This should not be merged and is merely a check to determine when our code base is ready for us to add PHP8 scondary CI